### PR TITLE
TRIVIAL: fix build workflow action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,6 +11,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
+      - run: rustup target add wasm32-unknown-unknown
       - run: sh build.sh
       - uses: actions/upload-artifact@v3
         with:

--- a/build.sh
+++ b/build.sh
@@ -13,6 +13,7 @@ perl -i -pe 's/\["cdylib", "rlib"\]/\["cdylib"\]/' examples/nft/Cargo.toml
 cargo fmt
 
 RUSTFLAGS='-C link-arg=-s' cargo build --all --target wasm32-unknown-unknown --release
+mkdir -p ./res
 cp $TARGET/wasm32-unknown-unknown/release/streaming.wasm ./res/streaming.wasm
 cp $TARGET/wasm32-unknown-unknown/release/finance.wasm ./res/finance.wasm
 cp $TARGET/wasm32-unknown-unknown/release/locked_token.wasm ./res/locked_token.wasm


### PR DESCRIPTION
by adding `wasm32-unknown-unknown` target architecture for rust toolchain